### PR TITLE
Fix platformer imports and add image fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Fuzzy
 
-A collection of small experiments. The `cosmic_invader` package now contains a simple browser-based shooter game.
+A collection of small experiments. There are two games in this repository:
 
-See `cosmic_invader/README.md` for details.
+- `cosmic_invader` – a browser-based shooter
+- `platformer` – a simple Mario-style platformer built with Pygame
+
+To run the platformer without changing directories, execute:
+
+```bash
+python run_platformer.py
+```
+
+See each subfolder for more information.

--- a/platformer/README.md
+++ b/platformer/README.md
@@ -1,0 +1,17 @@
+# Mario-Style Platformer
+
+This folder contains a basic side-scrolling platformer built with Pygame.
+You can start it from the repository root with `python run_platformer.py` or
+by running `python -m platformer.main`.
+
+## Asset Structure
+Place your images in the `assets/` directory with the following filenames:
+
+- `assets/player.png` – Player sprite
+- `assets/enemy.png` – Enemy sprite
+- `assets/ground.png` – Ground tile
+- `assets/platform.png` – Platform tile
+- `assets/flagpole.png` – Flag to complete the level
+
+If any of these files are missing, the game will fall back to simple colored
+rectangles so it still runs.

--- a/platformer/__init__.py
+++ b/platformer/__init__.py
@@ -1,0 +1,1 @@
+from .main import main

--- a/platformer/enemy.py
+++ b/platformer/enemy.py
@@ -1,0 +1,42 @@
+import pygame
+from .utils import load_image
+
+GRAVITY = 0.8
+MAX_FALL_SPEED = 12
+
+class Enemy(pygame.sprite.Sprite):
+    """Simple walking enemy."""
+    def __init__(self, pos, image_path="assets/enemy.png"):
+        super().__init__()
+        self.image = load_image(image_path)
+        self.rect = self.image.get_rect(topleft=pos)
+        self.direction = -1
+        self.speed = 2
+        self.vel_y = 0
+
+    def apply_gravity(self):
+        self.vel_y += GRAVITY
+        if self.vel_y > MAX_FALL_SPEED:
+            self.vel_y = MAX_FALL_SPEED
+
+    def update(self, level):
+        # horizontal movement
+        self.rect.x += self.direction * self.speed
+        for tile in level.get_collidable_tiles(self.rect):
+            if self.direction > 0:
+                self.rect.right = tile.left
+                self.direction = -1
+            elif self.direction < 0:
+                self.rect.left = tile.right
+                self.direction = 1
+
+        # vertical movement
+        self.apply_gravity()
+        self.rect.y += self.vel_y
+        for tile in level.get_collidable_tiles(self.rect):
+            if self.vel_y > 0:
+                self.rect.bottom = tile.top
+                self.vel_y = 0
+            elif self.vel_y < 0:
+                self.rect.top = tile.bottom
+                self.vel_y = 0

--- a/platformer/level.py
+++ b/platformer/level.py
@@ -1,0 +1,59 @@
+import pygame
+from .enemy import Enemy
+from .utils import load_image
+
+TILE_SIZE = 32
+
+class Level:
+    """Map that holds tiles, enemies, and goal."""
+    def __init__(self, map_data):
+        self.map_data = map_data
+        self.width = len(map_data[0]) * TILE_SIZE
+        self.height = len(map_data) * TILE_SIZE
+
+        self.ground_img = load_image('assets/ground.png')
+        self.platform_img = load_image('assets/platform.png')
+        self.flag_img = load_image('assets/flagpole.png')
+
+        self.tiles = []  # list of dict {'rect': rect, 'img': surface}
+        self.enemy_positions = []
+        self.flag_rect = None
+        self.start_pos = (0, 0)
+        self._parse_map()
+
+    def _parse_map(self):
+        for row_index, row in enumerate(self.map_data):
+            for col_index, cell in enumerate(row):
+                x = col_index * TILE_SIZE
+                y = row_index * TILE_SIZE
+                if cell == 'G':
+                    rect = pygame.Rect(x, y, TILE_SIZE, TILE_SIZE)
+                    self.tiles.append({'rect': rect, 'img': self.ground_img})
+                elif cell == 'P':
+                    rect = pygame.Rect(x, y, TILE_SIZE, TILE_SIZE)
+                    self.tiles.append({'rect': rect, 'img': self.platform_img})
+                elif cell == 'F':
+                    self.flag_rect = self.flag_img.get_rect(bottomleft=(x, y + TILE_SIZE))
+                elif cell == 'E':
+                    self.enemy_positions.append((x, y))
+                elif cell == 'S':
+                    self.start_pos = (x, y)
+
+    def create_enemies(self):
+        enemies = pygame.sprite.Group()
+        for pos in self.enemy_positions:
+            enemies.add(Enemy(pos))
+        return enemies
+
+    def get_collidable_tiles(self, rect):
+        return [t['rect'] for t in self.tiles if rect.colliderect(t['rect'])]
+
+    def draw(self, surface, offset_x):
+        for tile in self.tiles:
+            rect = tile['rect'].copy()
+            rect.x -= offset_x
+            surface.blit(tile['img'], rect)
+        if self.flag_rect:
+            rect = self.flag_rect.copy()
+            rect.x -= offset_x
+            surface.blit(self.flag_img, rect)

--- a/platformer/main.py
+++ b/platformer/main.py
@@ -1,0 +1,81 @@
+import pygame
+from .player import Player
+from .level import Level, TILE_SIZE
+
+SCREEN_WIDTH = 800
+SCREEN_HEIGHT = 600
+FPS = 60
+
+# Basic tile map. S=start, G=ground, P=platform, E=enemy, F=flag
+MAP_DATA = [
+    "............................................................................................",
+    "............................................................................................",
+    "............................P...............................................................",
+    ".................................................................E..........................",
+    "..........................................P.................................................",
+    ".........................................................F..................................",
+    "................................................P........................................S..",
+    "............................................................................................",
+    "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG"
+]
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+    pygame.display.set_caption("Platformer")
+    clock = pygame.time.Clock()
+
+    level = Level(MAP_DATA)
+    player = Player(level.start_pos)
+    enemies = level.create_enemies()
+
+    all_sprites = pygame.sprite.Group(player, enemies)
+
+    running = True
+    win = False
+    while running:
+        dt = clock.tick(FPS)
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+
+        keys = pygame.key.get_pressed()
+        player.update(keys, level)
+        enemies.update(level)
+
+        # Check collision with enemies
+        if pygame.sprite.spritecollide(player, enemies, False):
+            # Reset player to start if hit
+            player.rect.topleft = level.start_pos
+            player.vel_y = 0
+
+        # Check for level completion
+        if level.flag_rect and player.rect.colliderect(level.flag_rect):
+            win = True
+            running = False
+
+        # Camera follows player
+        offset_x = player.rect.centerx - SCREEN_WIDTH // 2
+        offset_x = max(0, min(offset_x, level.width - SCREEN_WIDTH))
+
+        screen.fill((92, 148, 252))  # sky blue background
+        level.draw(screen, offset_x)
+        for sprite in all_sprites:
+            rect = sprite.rect.copy()
+            rect.x -= offset_x
+            screen.blit(sprite.image, rect)
+
+        pygame.display.flip()
+
+    if win:
+        font = pygame.font.SysFont(None, 72)
+        text = font.render("You Win!", True, (255, 255, 255))
+        screen.blit(text, text.get_rect(center=(SCREEN_WIDTH//2, SCREEN_HEIGHT//2)))
+        pygame.display.flip()
+        pygame.time.wait(3000)
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/platformer/player.py
+++ b/platformer/player.py
@@ -1,0 +1,63 @@
+import pygame
+from .utils import load_image
+
+GRAVITY = 0.8
+MAX_FALL_SPEED = 12
+
+class Player(pygame.sprite.Sprite):
+    """Player controlled character."""
+    def __init__(self, pos, image_path="assets/player.png"):
+        super().__init__()
+        self.image = load_image(image_path)
+        self.rect = self.image.get_rect(topleft=pos)
+        self.vel_y = 0
+        self.speed = 5
+        self.jump_power = 16
+        self.on_ground = False
+
+    def handle_input(self, keys):
+        dx = 0
+        if keys[pygame.K_LEFT] or keys[pygame.K_a]:
+            dx = -self.speed
+        if keys[pygame.K_RIGHT] or keys[pygame.K_d]:
+            dx = self.speed if dx == 0 else dx
+        return dx
+
+    def apply_gravity(self):
+        self.vel_y += GRAVITY
+        if self.vel_y > MAX_FALL_SPEED:
+            self.vel_y = MAX_FALL_SPEED
+
+    def jump(self):
+        if self.on_ground:
+            self.vel_y = -self.jump_power
+            self.on_ground = False
+
+    def update(self, keys, level):
+        dx = self.handle_input(keys)
+        if (keys[pygame.K_SPACE] or keys[pygame.K_UP]) and self.on_ground:
+            self.jump()
+
+        # horizontal movement
+        self.rect.x += dx
+        for tile in level.get_collidable_tiles(self.rect):
+            if dx > 0:
+                self.rect.right = tile.left
+            elif dx < 0:
+                self.rect.left = tile.right
+
+        # vertical movement
+        self.apply_gravity()
+        self.rect.y += self.vel_y
+        collided = False
+        for tile in level.get_collidable_tiles(self.rect):
+            collided = True
+            if self.vel_y > 0:
+                self.rect.bottom = tile.top
+                self.vel_y = 0
+                self.on_ground = True
+            elif self.vel_y < 0:
+                self.rect.top = tile.bottom
+                self.vel_y = 0
+        if not collided:
+            self.on_ground = False

--- a/platformer/utils.py
+++ b/platformer/utils.py
@@ -1,0 +1,13 @@
+import pygame
+import os
+
+def load_image(path, size=(32,32), col=(255,0,255)):
+    """Load an image or return colored placeholder surface if file missing."""
+    if not os.path.isabs(path):
+        path = os.path.join(os.path.dirname(__file__), path)
+    try:
+        return pygame.image.load(path).convert_alpha()
+    except Exception:
+        surf = pygame.Surface(size)
+        surf.fill(col)
+        return surf

--- a/run_platformer.py
+++ b/run_platformer.py
@@ -1,0 +1,4 @@
+from platformer import main
+
+if __name__ == "__main__":
+    main.main()


### PR DESCRIPTION
## Summary
- make the platformer runnable from repo root via `run_platformer.py`
- switch to package-relative imports
- load placeholder surfaces when assets are missing
- document new launch method and fallbacks

## Testing
- `python -m py_compile platformer/*.py run_platformer.py`


------
https://chatgpt.com/codex/tasks/task_e_683a002d5b14832699d510e535076627